### PR TITLE
chore: add simple CI for running Go test

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,30 @@
+name: Go Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unix-tests:
+    name: Unix Unit Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go-version: ['1.19', '1.20']
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Install golint
+      run: go install golang.org/x/lint/golint@latest
+
+    - name: Go Test
+      run: go test


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* 

This change adds a simple CI workflow which runs `go test` against the repo for new PRs. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
