### PR TITLE
chore: add parameter malleability integ tests

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -121,6 +121,9 @@ func TestParameterMalleabilityRemoval(t *testing.T) {
 			}
 
 			ciphertext, err := io.ReadAll(getOutput.Body)
+			if err != nil {
+				t.Fatalf("failed to read ciphertext from getObject output, %v", err)
+			}
 
 			// Modify metadata
 			metadata := getOutput.Metadata


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds tests which attempt to modify the crypto parameters in the ciphertext object's metadata to validate against downgrade attacks. 

See also [the Java equivalent here](https://github.com/aws/amazon-s3-encryption-client-java/blob/main/src/test/java/software/amazon/encryption/s3/ParameterMalleabilityTest.java).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
