### PR TITLE
chore: remove personal alias

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -19,11 +19,11 @@ import (
 
 const version = "v3"
 
-const defaultBucket = "s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultBucket = "s3-encryption-client-v3-go-us-west-2"
 const bucketEnvvar = "BUCKET"
 const defaultRegion = "us-west-2"
 const regionEnvvar = "AWS_REGION"
-const defaultAwsKmsAlias = "s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultAwsKmsAlias = "s3-encryption-client-v3-go-us-west-2"
 const awsKmsAliasEnvvar = "AWS_KMS_ALIAS"
 const awsAccountIdEnvvar = "AWS_ACCOUNT_ID"
 

--- a/testvectors/compatibility_test.go
+++ b/testvectors/compatibility_test.go
@@ -20,13 +20,11 @@ import (
 	"testing"
 )
 
-// This is duplicated in integ_test.go,
-// TODO: refactor to share
-const defaultBucket = "s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultBucket = "s3-encryption-client-v3-go-us-west-2"
 const bucketEnvvar = "BUCKET"
 const defaultRegion = "us-west-2"
 const regionEnvvar = "AWS_REGION"
-const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-us-west-2"
 const awsKmsAliasEnvvar = "AWS_KMS_ALIAS"
 const awsAccountIdEnvvar = "AWS_ACCOUNT_ID"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removing personal resources from integ test defaults. 

To avoid this in the future, I've augmented my `.zshrc` like so:

```
alias gitodo="git diff | grep TODO | cut -d '/' -f3"
alias gitmeout="git diff | grep justplaz | cut -d '/' -f3"
alias gs="`echo gitodo` && `echo gitmeout` && git status"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
