### PR TITLE
fix: create default s3 client when loading instruction file

### DIFF
--- a/strategy.go
+++ b/strategy.go
@@ -135,11 +135,11 @@ func (load DefaultLoadStrategy) Load(ctx context.Context, req *LoadStrategyReque
 
 	var client GetObjectAPIClient
 	if load.client == nil {
-		config, err := config.LoadDefaultConfig(context.Background())
+		cfg, err := config.LoadDefaultConfig(context.Background())
 		if err != nil {
 			return ObjectMetadata{}, fmt.Errorf("unable to create S3 client to load instruction file: ")
 		}
-		client = s3.NewFromConfig(config)
+		client = s3.NewFromConfig(cfg)
 	} else {
 		client = load.client
 	}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While working on integ tests for the new load strategy behavior, 
I encountered a nil pointer on load. 
This PR creates a default S3 client to fetch the instruction file when needed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
