### PR TITLE
feat: add legacyWrappingAlgorithms option on keyrings

### DIFF
--- a/decryption_client_v3_test.go
+++ b/decryption_client_v3_test.go
@@ -28,7 +28,9 @@ func TestDecryptionClientV3_GetObject(t *testing.T) {
 	tKmsConfig.EndpointResolverWithOptions = awstesting.TestEndpointResolver(ts.URL)
 	kmsClient := kms.NewFromConfig(tKmsConfig)
 
-	keyring := NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, false)
+	keyring := NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, func(options *KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	})
 	cmm, err := NewCryptographicMaterialsManager(keyring)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
@@ -95,7 +97,9 @@ func TestDecryptionClientV3_GetObject_V1Interop_KMS_AESCBC(t *testing.T) {
 	tKmsConfig.EndpointResolverWithOptions = awstesting.TestEndpointResolver(ts.URL)
 	kmsClient := kms.NewFromConfig(tKmsConfig)
 
-	keyring := NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, true)
+	keyring := NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, func(options *KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = true
+	})
 	cmm, err := NewCryptographicMaterialsManager(keyring)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
@@ -166,7 +170,9 @@ func TestDecryptionClientV3_GetObject_V1Interop_KMS_AESGCM(t *testing.T) {
 	tKmsConfig.EndpointResolverWithOptions = awstesting.TestEndpointResolver(ts.URL)
 	kmsClient := kms.NewFromConfig(tKmsConfig)
 
-	keyring := NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, true)
+	keyring := NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, func(options *KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = true
+	})
 	cmm, err := NewCryptographicMaterialsManager(keyring)
 	if err != nil {
 		t.Errorf("expected no error, but received %v", err)
@@ -251,7 +257,9 @@ func TestDecryptionClientV3_GetObject_OnlyDecryptsRegisteredAlgorithms(t *testin
 	}{
 		"unsupported cek": {
 			Client: func() *S3EncryptionClientV3 {
-				keyring := NewKmsDecryptOnlyAnyKeyKeyring(kms.NewFromConfig(awstesting.Config()), false)
+				keyring := NewKmsDecryptOnlyAnyKeyKeyring(kms.NewFromConfig(awstesting.Config()), func(options *KeyringOptions) {
+					options.EnableLegacyWrappingAlgorithms = false
+				})
 				cmm, err := NewCryptographicMaterialsManager(keyring)
 				if err != nil {
 					t.Fatalf("expected no error, got %v", err)

--- a/encryption_client_v3_test.go
+++ b/encryption_client_v3_test.go
@@ -83,8 +83,10 @@ func TestEncryptionClientV3_PutObject_KMSCONTEXT_AESGCM(t *testing.T) {
 	var md MaterialDescription
 	iv, _ := hex.DecodeString("ae325acae2bfd5b9c3d0b813")
 	kmsWithStaticIV := keyringWithStaticTestIV{
-		IV:      iv,
-		Keyring: NewKmsKeyring(kmsClient, "test-key-id", md, false),
+		IV: iv,
+		Keyring: NewKmsKeyring(kmsClient, "test-key-id", md, func(options *KeyringOptions) {
+			options.EnableLegacyWrappingAlgorithms = false
+		}),
 	}
 
 	tConfig := awstesting.Config()

--- a/integ_test.go
+++ b/integ_test.go
@@ -143,7 +143,9 @@ func TestInteg_DecryptFixtures(t *testing.T) {
 		t.Run(c.CEKAlg+"-"+c.Lang, func(t *testing.T) {
 			s3Client := s3.NewFromConfig(cfg)
 			kmsClient := kms.NewFromConfig(cfg)
-			keyringWithContext := s3crypto.NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, false)
+			keyringWithContext := s3crypto.NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, func(options *s3crypto.KeyringOptions) {
+				options.EnableLegacyWrappingAlgorithms = false
+			})
 			cmm, err := s3crypto.NewCryptographicMaterialsManager(keyringWithContext)
 			if err != nil {
 				t.Fatalf("failed to create new CMM")
@@ -151,7 +153,9 @@ func TestInteg_DecryptFixtures(t *testing.T) {
 
 			var decClient *s3crypto.S3EncryptionClientV3
 			if c.CEKAlg == "aes_cbc" {
-				keyring := s3crypto.NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, true)
+				keyring := s3crypto.NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, func(options *s3crypto.KeyringOptions) {
+					options.EnableLegacyWrappingAlgorithms = true
+				})
 				cmmCbc, err := s3crypto.NewCryptographicMaterialsManager(keyring)
 				decClient, err = s3crypto.NewS3EncryptionClientV3(s3Client, cmmCbc, func(clientOptions *s3crypto.EncryptionClientOptions) {
 					clientOptions.EnableLegacyUnauthenticatedModes = true
@@ -237,7 +241,9 @@ func getEncryptFixtureBuilder(t *testing.T, cfg aws.Config, kek, alias, region, 
 
 		kmsSvc := kms.NewFromConfig(cfg)
 		var matDesc s3crypto.MaterialDescription
-		kmsKeyring = s3crypto.NewKmsKeyring(kmsSvc, arn, matDesc, false)
+		kmsKeyring = s3crypto.NewKmsKeyring(kmsSvc, arn, matDesc, func(options *s3crypto.KeyringOptions) {
+			options.EnableLegacyWrappingAlgorithms = false
+		})
 	default:
 		t.Fatalf("unknown fixture KEK, %v", kek)
 	}

--- a/s3_ec_integ_test.go
+++ b/s3_ec_integ_test.go
@@ -43,7 +43,9 @@ func TestIntegS3ECHeadObject(t *testing.T) {
 
 	kmsClient := kms.NewFromConfig(cfg)
 	var matDesc s3crypto.MaterialDescription
-	cmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsKeyring(kmsClient, arn, matDesc, false))
+	cmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsKeyring(kmsClient, arn, matDesc, func(options *s3crypto.KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	}))
 	if err != nil {
 		t.Fatalf("error while creating new CMM")
 	}
@@ -115,7 +117,9 @@ func TestIntegKmsContext(t *testing.T) {
 
 	kmsClient := kms.NewFromConfig(cfg)
 	var matDesc s3crypto.MaterialDescription
-	cmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsKeyring(kmsClient, arn, matDesc, false))
+	cmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsKeyring(kmsClient, arn, matDesc, func(options *s3crypto.KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	}))
 	if err != nil {
 		t.Fatalf("error while creating new CMM")
 	}
@@ -187,7 +191,9 @@ func TestIntegKmsContextDecryptAny(t *testing.T) {
 
 	kmsClient := kms.NewFromConfig(cfg)
 	var matDesc s3crypto.MaterialDescription
-	cmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsKeyring(kmsClient, arn, matDesc, false))
+	cmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsKeyring(kmsClient, arn, matDesc, func(options *s3crypto.KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	}))
 	if err != nil {
 		t.Fatalf("error while creating new CMM")
 	}
@@ -203,7 +209,9 @@ func TestIntegKmsContextDecryptAny(t *testing.T) {
 	}
 
 	// decrypt with AnyKey
-	anyKeyCmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, false))
+	anyKeyCmm, err := s3crypto.NewCryptographicMaterialsManager(s3crypto.NewKmsDecryptOnlyAnyKeyKeyring(kmsClient, func(options *s3crypto.KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	}))
 	s3EncryptionClientAnyKey, err := s3crypto.NewS3EncryptionClientV3(s3Client, anyKeyCmm)
 	if err != nil {
 		t.Fatalf("error while creating new CMM")

--- a/s3_encryption_client_v3.go
+++ b/s3_encryption_client_v3.go
@@ -47,10 +47,10 @@ func NewS3EncryptionClientV3(s3Client *s3.Client, CryptographicMaterialsManager 
 	wrappedClient := s3Client
 	// default options
 	options := EncryptionClientOptions{
-		MinFileSize:                   DefaultMinFileSize,
-		Logger:                        log.Default(),
-		CryptographicMaterialsManager: CryptographicMaterialsManager,
-		EnableLegacyUnauthenticatedModes:             false,
+		MinFileSize:                      DefaultMinFileSize,
+		Logger:                           log.Default(),
+		CryptographicMaterialsManager:    CryptographicMaterialsManager,
+		EnableLegacyUnauthenticatedModes: false,
 	}
 	for _, fn := range optFns {
 		fn(&options)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For parity with the S3EC Java there MUST be a `legacyWrappingAlgorithm` option on Decrypt to explicitly read KMS V1 messages, otherwise the keyring MUST not attempt to read the message.

#20 fixes test vectors

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
