### PR TITLE
fix: use different constants for kms keyring

### DIFF
--- a/materials/kms_keyring.go
+++ b/materials/kms_keyring.go
@@ -17,7 +17,7 @@ const (
 	// KMSContextKeyring is a constant used during decryption to build a kms+context keyring
 	KMSContextKeyring = "kms+context"
 
-	kmsDefaultEncryptionContextKey = "AESGCMNoPadding"
+	kmsDefaultEncryptionContextKey = "AES/GCM/NoPadding"
 	kmsAWSCEKContextKey            = "aws:x-amz-cek-alg"
 	kmsMismatchCEKAlg              = "the content encryption algorithm used at encryption time does not match the algorithm stored for decryption time. The object may be altered or corrupted"
 	kmsReservedKeyConflictErrMsg   = "conflict in reserved KMS Encryption Context key %s. This value is reserved for the S3 Encryption client and cannot be set by the user"

--- a/materials/materials.go
+++ b/materials/materials.go
@@ -6,7 +6,7 @@ package materials
 const (
 	gcmKeySize       = 32
 	gcmNonceSize     = 12
-	defaultAlgorithm = "AESGCMNoPadding"
+	defaultAlgorithm = "AES/GCM/NoPadding"
 )
 
 type DecryptionMaterials struct {

--- a/testvectors/go.mod
+++ b/testvectors/go.mod
@@ -11,7 +11,7 @@ require (
 )
 
 require (
-	github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231113023408-6345feb6deec // indirect
+	github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231116194958-75c36ac914ec // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.24 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.3 // indirect

--- a/testvectors/go.sum
+++ b/testvectors/go.sum
@@ -14,6 +14,8 @@ github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231113005832-5538b9b4755d
 github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231113005832-5538b9b4755d/go.mod h1:h9NEsWqsylYOVlK20yqhSGNaBBW9xW7keOwXwDu8Ir4=
 github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231113023408-6345feb6deec h1:W9FiDVR/t0Y/d+xigOn9HdWGuJJTztPjYcBaGhgQ6k4=
 github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231113023408-6345feb6deec/go.mod h1:h9NEsWqsylYOVlK20yqhSGNaBBW9xW7keOwXwDu8Ir4=
+github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231116194958-75c36ac914ec h1:JOIECR+lm1TiQHpM94dsewSudAtsruYr+wPuXCqb1ik=
+github.com/aws/amazon-s3-encryption-client-go v0.0.0-20231116194958-75c36ac914ec/go.mod h1:h9NEsWqsylYOVlK20yqhSGNaBBW9xW7keOwXwDu8Ir4=
 github.com/aws/aws-sdk-go v1.44.327 h1:ZS8oO4+7MOBLhkdwIhgtVeDzCeWOlTfKJS7EgggbIEY=
 github.com/aws/aws-sdk-go v1.44.327/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.18.0 h1:882kkTpSFhdgYRKVZ/VCgf7sd0ru57p2JCxz4/oN5RY=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `\` characters were removed by an over aggressive refactor, this PR restores them to restore compatibility.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
