### PR TITLE
fix: allow decryption of non-legacy authenticated objects when legacy modes are enabled

### DIFF
--- a/v3/materials/kms_keyring.go
+++ b/v3/materials/kms_keyring.go
@@ -156,7 +156,7 @@ func (k *KmsAnyKeyKeyring) OnEncrypt(ctx context.Context, materials *EncryptionM
 func (k *KmsAnyKeyKeyring) OnDecrypt(ctx context.Context, materials *DecryptionMaterials, encryptedDataKey DataKey) (*CryptographicMaterials, error) {
 	if materials.DataKey.DataKeyAlgorithm == KMSKeyring && k.legacyWrappingAlgorithms {
 		return commonDecrypt(ctx, materials, encryptedDataKey, nil, nil, k.kmsClient)
-	} else if materials.DataKey.DataKeyAlgorithm == KMSContextKeyring && !k.legacyWrappingAlgorithms {
+	} else if materials.DataKey.DataKeyAlgorithm == KMSContextKeyring {
 		return commonDecrypt(ctx, materials, encryptedDataKey, nil, materials.MaterialDescription, k.kmsClient)
 	} else {
 		return nil, fmt.Errorf("x-amz-cek-alg value `%s` did not match an expected algorithm", materials.DataKey.DataKeyAlgorithm)

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 )
 
-const defaultBucket = "s3-encryption-client-v3-go-us-west-2"
+const defaultBucket = "s3-encryption-client-v3-go-justplaz-us-west-2"
 const bucketEnvvar = "BUCKET"
-const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-us-west-2"
+const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-justplaz-us-west-2"
 
 const awsKmsAliasEnvvar = "AWS_KMS_ALIAS"
 const awsAccountIdEnvvar = "AWS_ACCOUNT_ID"
@@ -60,6 +60,50 @@ func LoadAwsKmsAlias() string {
 func LoadAwsAccountId() string {
 	return os.Getenv(awsAccountIdEnvvar)
 }
+
+// This generates CBC ciphertexts that the s3_integ_test decrypts.
+// This is meant to be a utility function, not a test function,
+// but for simplicity uses functions from s3_integ_test.
+// To avoid running it each test run, it is left commented out.
+//func TestGenerateCBCIntegTests(t *testing.T) {
+//	arn := "arn:aws:kms:us-west-2:370957321024:alias/S3EC-Go-Github-KMS-Key"
+//	bucket := "s3ec-go-github-test-bucket"
+//	region := "us-west-2"
+//	ctx := context.Background()
+//	cfg, _ := config.LoadDefaultConfig(ctx,
+//		config.WithRegion(region),
+//	)
+//
+//	s3Client := s3.NewFromConfig(cfg)
+//	fixtures := getFixtures(t, s3Client, "aes_cbc", bucket)
+//	// V2 client
+//	var handler s3cryptoV2.CipherDataGenerator
+//	sessKms, _ := sessionV1.NewSession(&awsV1.Config{
+//		Region: aws.String(region),
+//	})
+//
+//	// KMS v1
+//	kmsSvc := kmsV1.New(sessKms)
+//	handler = s3cryptoV2.NewKMSKeyGenerator(kmsSvc, arn)
+//	// AES-CBC content cipher
+//	builder := s3cryptoV2.AESCBCContentCipherBuilder(handler, s3cryptoV2.AESCBCPadder)
+//	encClient := s3cryptoV2.NewEncryptionClient(sessKms, builder)
+//
+//	for caseKey, plaintext := range fixtures.Plaintexts {
+//		_, err := encClient.PutObject(&s3V1.PutObjectInput{
+//			Bucket: aws.String(bucket),
+//			Key: aws.String(
+//				fmt.Sprintf("%s/%s/language_Go/ciphertext_test_case_%s",
+//					fixtures.BaseFolder, version, caseKey),
+//			),
+//			Body: bytes.NewReader(plaintext),
+//		})
+//		if err != nil {
+//			t.Fatalf("failed to upload encrypted fixture, %v", err)
+//		}
+//	}
+//
+//}
 
 func TestKmsV1toV3_CBC(t *testing.T) {
 	bucket := LoadBucket()
@@ -389,6 +433,18 @@ func TestInstructionFileV2toV3(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("error while decrypting: %v", err)
+	}
+
+	// todo - why is this empty??
+	for key, val := range result.Metadata {
+
+		fmt.Printf("printing..")
+		// Convert each key/value pair in m to a string
+		s := fmt.Sprintf("%s=\"%s\"", key, val)
+
+		// Do whatever you want to do with the string;
+		// in this example I just print out each of them.
+		fmt.Println(s)
 	}
 
 	decryptedPlaintext, err := io.ReadAll(result.Body)

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -504,96 +504,96 @@ func TestNegativeKeyringOption(t *testing.T) {
 	}
 }
 
-func TestEnableLegacyDecryptBothFormats(t *testing.T) {
-	bucket := LoadBucket()
-	kmsKeyAlias := LoadAwsKmsAlias()
-
-	cekAlgCbc := "aes_cbc"
-	keyCbc := "crypto_tests/" + cekAlgCbc + "/v3/language_Go/BothFormats_CBC.txt"
-	cekAlgGcm := "aes_gcm"
-	keyGcm := "crypto_tests/" + cekAlgGcm + "/v3/language_Go/BothFormats_GCM.txt"
-	region := "us-west-2"
-	plaintext := "This is a test.\n"
-
-	// V2 Client
-	var handler s3cryptoV2.CipherDataGenerator
-	sessKms, err := sessionV1.NewSession(&awsV1.Config{
-		Region: aws.String(region),
-	})
-
-	// KMS v1
-	kmsSvc := kmsV1.New(sessKms)
-	handler = s3cryptoV2.NewKMSKeyGenerator(kmsSvc, kmsKeyAlias)
-	// AES-CBC content cipher
-	builder := s3cryptoV2.AESCBCContentCipherBuilder(handler, s3cryptoV2.AESCBCPadder)
-	encClient := s3cryptoV2.NewEncryptionClient(sessKms, builder)
-
-	_, err = encClient.PutObject(&s3V1.PutObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(keyCbc),
-		Body:   bytes.NewReader([]byte(plaintext)),
-	})
-	if err != nil {
-		log.Fatalf("error calling putObject: %v", err)
-	}
-	fmt.Printf("successfully uploaded file to %s/%s\n", bucket, keyCbc)
-
-	ctx := context.Background()
-	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(region),
-	)
-
-	kmsV2 := kms.NewFromConfig(cfg)
-	cmm, err := materials.NewCryptographicMaterialsManager(materials.NewKmsKeyring(kmsV2, kmsKeyAlias, func(options *materials.KeyringOptions) {
-		options.EnableLegacyWrappingAlgorithms = false
-	}))
-	if err != nil {
-		t.Fatalf("error while creating new CMM")
-	}
-
-	s3V2 := s3.NewFromConfig(cfg)
-	s3ecV3, err := client.New(s3V2, cmm, func(clientOptions *client.EncryptionClientOptions) {
-		clientOptions.EnableLegacyUnauthenticatedModes = true
-	})
-
-	_, err = s3ecV3.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(keyGcm),
-		Body:   bytes.NewReader([]byte(plaintext)),
-	})
-	if err != nil {
-		t.Fatalf("error while calling PutObject!")
-	}
-
-	getResponseCbc, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(keyCbc),
-	})
-	if err != nil {
-		t.Fatalf("error while calling GetObject for CBC")
-	}
-	// ensure CBC matches
-	decryptedPlaintext, err := io.ReadAll(getResponseCbc.Body)
-	if err != nil {
-		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
-	}
-	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
-		t.Errorf("expect %v text, got %v", e, a)
-	}
-
-	getResponseGcm, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(keyGcm),
-	})
-	if err != nil {
-		t.Fatalf("error while calling GetObject for GCM")
-	}
-	// ensure CBC matches
-	decryptedPlaintext, err = io.ReadAll(getResponseGcm.Body)
-	if err != nil {
-		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
-	}
-	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
-		t.Errorf("expect %v text, got %v", e, a)
-	}
-}
+//func TestEnableLegacyDecryptBothFormats(t *testing.T) {
+//	bucket := LoadBucket()
+//	kmsKeyAlias := LoadAwsKmsAlias()
+//
+//	cekAlgCbc := "aes_cbc"
+//	keyCbc := "crypto_tests/" + cekAlgCbc + "/v3/language_Go/BothFormats_CBC.txt"
+//	cekAlgGcm := "aes_gcm"
+//	keyGcm := "crypto_tests/" + cekAlgGcm + "/v3/language_Go/BothFormats_GCM.txt"
+//	region := "us-west-2"
+//	plaintext := "This is a test.\n"
+//
+//	// V2 Client
+//	var handler s3cryptoV2.CipherDataGenerator
+//	sessKms, err := sessionV1.NewSession(&awsV1.Config{
+//		Region: aws.String(region),
+//	})
+//
+//	// KMS v1
+//	kmsSvc := kmsV1.New(sessKms)
+//	handler = s3cryptoV2.NewKMSKeyGenerator(kmsSvc, kmsKeyAlias)
+//	// AES-CBC content cipher
+//	builder := s3cryptoV2.AESCBCContentCipherBuilder(handler, s3cryptoV2.AESCBCPadder)
+//	encClient := s3cryptoV2.NewEncryptionClient(sessKms, builder)
+//
+//	_, err = encClient.PutObject(&s3V1.PutObjectInput{
+//		Bucket: aws.String(bucket),
+//		Key:    aws.String(keyCbc),
+//		Body:   bytes.NewReader([]byte(plaintext)),
+//	})
+//	if err != nil {
+//		log.Fatalf("error calling putObject: %v", err)
+//	}
+//	fmt.Printf("successfully uploaded file to %s/%s\n", bucket, keyCbc)
+//
+//	ctx := context.Background()
+//	cfg, err := config.LoadDefaultConfig(ctx,
+//		config.WithRegion(region),
+//	)
+//
+//	kmsV2 := kms.NewFromConfig(cfg)
+//	cmm, err := materials.NewCryptographicMaterialsManager(materials.NewKmsKeyring(kmsV2, kmsKeyAlias, func(options *materials.KeyringOptions) {
+//		options.EnableLegacyWrappingAlgorithms = false
+//	}))
+//	if err != nil {
+//		t.Fatalf("error while creating new CMM")
+//	}
+//
+//	s3V2 := s3.NewFromConfig(cfg)
+//	s3ecV3, err := client.New(s3V2, cmm, func(clientOptions *client.EncryptionClientOptions) {
+//		clientOptions.EnableLegacyUnauthenticatedModes = true
+//	})
+//
+//	_, err = s3ecV3.PutObject(ctx, &s3.PutObjectInput{
+//		Bucket: aws.String(bucket),
+//		Key:    aws.String(keyGcm),
+//		Body:   bytes.NewReader([]byte(plaintext)),
+//	})
+//	if err != nil {
+//		t.Fatalf("error while calling PutObject!")
+//	}
+//
+//	getResponseCbc, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
+//		Bucket: aws.String(bucket),
+//		Key:    aws.String(keyCbc),
+//	})
+//	if err != nil {
+//		t.Fatalf("error while calling GetObject for CBC")
+//	}
+//	// ensure CBC matches
+//	decryptedPlaintext, err := io.ReadAll(getResponseCbc.Body)
+//	if err != nil {
+//		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
+//	}
+//	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
+//		t.Errorf("expect %v text, got %v", e, a)
+//	}
+//
+//	getResponseGcm, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
+//		Bucket: aws.String(bucket),
+//		Key:    aws.String(keyGcm),
+//	})
+//	if err != nil {
+//		t.Fatalf("error while calling GetObject for GCM")
+//	}
+//	// ensure CBC matches
+//	decryptedPlaintext, err = io.ReadAll(getResponseGcm.Body)
+//	if err != nil {
+//		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
+//	}
+//	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
+//		t.Errorf("expect %v text, got %v", e, a)
+//	}
+//}

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 )
 
-const defaultBucket = "s3-encryption-client-v3-go-us-west-2"
+const defaultBucket = "s3-encryption-client-v3-go-justplaz-us-west-2"
 const bucketEnvvar = "BUCKET"
-const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-us-west-2"
+const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-justplaz-us-west-2"
 
 const awsKmsAliasEnvvar = "AWS_KMS_ALIAS"
 const awsAccountIdEnvvar = "AWS_ACCOUNT_ID"
@@ -458,5 +458,98 @@ func TestNegativeKeyringOption(t *testing.T) {
 	if err == nil {
 		t.Fatalf("error while calling GetObject, expected to FAIL")
 	}
+}
 
+func TestEnableLegacyDecryptBothFormats(t *testing.T) {
+	bucket := LoadBucket()
+	kmsKeyAlias := LoadAwsKmsAlias()
+
+	cekAlgCbc := "aes_cbc"
+	keyCbc := "crypto_tests/" + cekAlgCbc + "/v3/language_Go/BothFormats_CBC.txt"
+	cekAlgGcm := "aes_gcm"
+	keyGcm := "crypto_tests/" + cekAlgGcm + "/v3/language_Go/BothFormats_GCM.txt"
+	region := "us-west-2"
+	plaintext := "This is a test.\n"
+
+	// V2 Client
+	var handler s3cryptoV2.CipherDataGenerator
+	sessKms, err := sessionV1.NewSession(&awsV1.Config{
+		Region: aws.String(region),
+	})
+
+	// KMS v1
+	kmsSvc := kmsV1.New(sessKms)
+	handler = s3cryptoV2.NewKMSKeyGenerator(kmsSvc, kmsKeyAlias)
+	// AES-CBC content cipher
+	builder := s3cryptoV2.AESCBCContentCipherBuilder(handler, s3cryptoV2.AESCBCPadder)
+	encClient := s3cryptoV2.NewEncryptionClient(sessKms, builder)
+
+	_, err = encClient.PutObject(&s3V1.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyCbc),
+		Body:   bytes.NewReader([]byte(plaintext)),
+	})
+	if err != nil {
+		log.Fatalf("error calling putObject: %v", err)
+	}
+	fmt.Printf("successfully uploaded file to %s/%s\n", bucket, keyCbc)
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+	)
+
+	kmsV2 := kms.NewFromConfig(cfg)
+	cmm, err := materials.NewCryptographicMaterialsManager(materials.NewKmsKeyring(kmsV2, kmsKeyAlias, func(options *materials.KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	}))
+	if err != nil {
+		t.Fatalf("error while creating new CMM")
+	}
+
+	s3V2 := s3.NewFromConfig(cfg)
+	s3ecV3, err := client.New(s3V2, cmm, func(clientOptions *client.EncryptionClientOptions) {
+		clientOptions.EnableLegacyUnauthenticatedModes = true
+	})
+
+	_, err = s3ecV3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyGcm),
+		Body:   bytes.NewReader([]byte(plaintext)),
+	})
+	if err != nil {
+		t.Fatalf("error while calling PutObject!")
+	}
+
+	getResponseCbc, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyCbc),
+	})
+	if err != nil {
+		t.Fatalf("error while calling GetObject for CBC")
+	}
+	// ensure CBC matches
+	decryptedPlaintext, err := io.ReadAll(getResponseCbc.Body)
+	if err != nil {
+		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
+	}
+	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
+		t.Errorf("expect %v text, got %v", e, a)
+	}
+
+	getResponseGcm, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyGcm),
+	})
+	if err != nil {
+		t.Fatalf("error while calling GetObject for GCM")
+	}
+	// ensure CBC matches
+	decryptedPlaintext, err = io.ReadAll(getResponseGcm.Body)
+	if err != nil {
+		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
+	}
+	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
+		t.Errorf("expect %v text, got %v", e, a)
+	}
 }

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -504,6 +504,95 @@ func TestNegativeKeyringOption(t *testing.T) {
 	}
 }
 
+func TestEnableLegacyDecryptBothFormatsFails(t *testing.T) {
+	bucket := LoadBucket()
+	kmsKeyAlias := LoadAwsKmsAlias()
+
+	cekAlgCbc := "aes_cbc"
+	keyCbc := "crypto_tests/" + cekAlgCbc + "/v3/language_Go/BothFormats_CBC.txt"
+	cekAlgGcm := "aes_gcm"
+	keyGcm := "crypto_tests/" + cekAlgGcm + "/v3/language_Go/BothFormats_GCM.txt"
+	region := "us-west-2"
+	plaintext := "This is a test.\n"
+
+	// V2 Client
+	var handler s3cryptoV2.CipherDataGenerator
+	sessKms, err := sessionV1.NewSession(&awsV1.Config{
+		Region: aws.String(region),
+	})
+
+	// KMS v1
+	kmsSvc := kmsV1.New(sessKms)
+	handler = s3cryptoV2.NewKMSKeyGenerator(kmsSvc, kmsKeyAlias)
+	// AES-CBC content cipher
+	builder := s3cryptoV2.AESCBCContentCipherBuilder(handler, s3cryptoV2.AESCBCPadder)
+	encClient := s3cryptoV2.NewEncryptionClient(sessKms, builder)
+
+	_, err = encClient.PutObject(&s3V1.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyCbc),
+		Body:   bytes.NewReader([]byte(plaintext)),
+	})
+	if err != nil {
+		log.Fatalf("error calling putObject: %v", err)
+	}
+	fmt.Printf("successfully uploaded file to %s/%s\n", bucket, keyCbc)
+
+	ctx := context.Background()
+	cfg, err := config.LoadDefaultConfig(ctx,
+		config.WithRegion(region),
+	)
+
+	kmsV2 := kms.NewFromConfig(cfg)
+	cmm, err := materials.NewCryptographicMaterialsManager(materials.NewKmsKeyring(kmsV2, kmsKeyAlias, func(options *materials.KeyringOptions) {
+		options.EnableLegacyWrappingAlgorithms = false
+	}))
+	if err != nil {
+		t.Fatalf("error while creating new CMM")
+	}
+
+	s3V2 := s3.NewFromConfig(cfg)
+	s3ecV3, err := client.New(s3V2, cmm, func(clientOptions *client.EncryptionClientOptions) {
+		clientOptions.EnableLegacyUnauthenticatedModes = true
+	})
+
+	_, err = s3ecV3.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyGcm),
+		Body:   bytes.NewReader([]byte(plaintext)),
+	})
+	if err != nil {
+		t.Fatalf("error while calling PutObject!")
+	}
+
+	getResponseCbc, err := s3ecV3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyCbc),
+	})
+	if err != nil {
+		t.Fatalf("error while calling GetObject for CBC")
+	}
+	// ensure CBC matches
+	decryptedPlaintext, err := io.ReadAll(getResponseCbc.Body)
+	if err != nil {
+		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)
+	}
+	if e, a := []byte(plaintext), decryptedPlaintext; !bytes.Equal(e, a) {
+		t.Errorf("expect %v text, got %v", e, a)
+	}
+
+	_, err = s3ecV3.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(keyGcm),
+	})
+	if err == nil {
+		t.Fatalf("expected error while calling GetObject for GCM!")
+	}
+	if err != nil {
+		fmt.Println("GCM failed to decrypt! this is a bug to be fixed by PR 45.")
+	}
+}
+
 //func TestEnableLegacyDecryptBothFormats(t *testing.T) {
 //	bucket := LoadBucket()
 //	kmsKeyAlias := LoadAwsKmsAlias()
@@ -588,7 +677,7 @@ func TestNegativeKeyringOption(t *testing.T) {
 //	if err != nil {
 //		t.Fatalf("error while calling GetObject for GCM")
 //	}
-//	// ensure CBC matches
+//	// ensure GCM matches
 //	decryptedPlaintext, err = io.ReadAll(getResponseGcm.Body)
 //	if err != nil {
 //		t.Fatalf("failed to read decrypted plaintext into byte array: %v", err)

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 )
 
-const defaultBucket = "s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultBucket = "s3-encryption-client-v3-go-us-west-2"
 const bucketEnvvar = "BUCKET"
-const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-us-west-2"
 
 const awsKmsAliasEnvvar = "AWS_KMS_ALIAS"
 const awsAccountIdEnvvar = "AWS_ACCOUNT_ID"

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 )
 
-const defaultBucket = "s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultBucket = "s3-encryption-client-v3-go-us-west-2"
 const bucketEnvvar = "BUCKET"
-const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-justplaz-us-west-2"
+const defaultAwsKmsAlias = "arn:aws:kms:us-west-2:657301468084:alias/s3-encryption-client-v3-go-us-west-2"
 
 const awsKmsAliasEnvvar = "AWS_KMS_ALIAS"
 const awsAccountIdEnvvar = "AWS_ACCOUNT_ID"
@@ -433,18 +433,6 @@ func TestInstructionFileV2toV3(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("error while decrypting: %v", err)
-	}
-
-	// todo - why is this empty??
-	for key, val := range result.Metadata {
-
-		fmt.Printf("printing..")
-		// Convert each key/value pair in m to a string
-		s := fmt.Sprintf("%s=\"%s\"", key, val)
-
-		// Do whatever you want to do with the string;
-		// in this example I just print out each of them.
-		fmt.Println(s)
 	}
 
 	decryptedPlaintext, err := io.ReadAll(result.Body)

--- a/v3/testvectors/s3_integ_test.go
+++ b/v3/testvectors/s3_integ_test.go
@@ -102,7 +102,8 @@ func TestInteg_DecryptFixtures(t *testing.T) {
 		Lang    string
 		Version string
 	}{
-		{CEKAlg: "aes_cbc", Lang: "Go", Version: "v3"}, // v3 doesn't support CBC but that's where the files are
+		{CEKAlg: "aes_cbc", Lang: "Go", Version: "v2"},
+		{CEKAlg: "aes_cbc", Lang: "Java", Version: "v1"},
 		{CEKAlg: "aes_gcm", Lang: "Go", Version: "v3"},
 		{CEKAlg: "aes_gcm", Lang: "Java", Version: "v2"},
 		{CEKAlg: "aes_gcm", Lang: "Java", Version: "v3"},

--- a/v3/testvectors/s3_integ_test.go
+++ b/v3/testvectors/s3_integ_test.go
@@ -102,8 +102,7 @@ func TestInteg_DecryptFixtures(t *testing.T) {
 		Lang    string
 		Version string
 	}{
-		{CEKAlg: "aes_cbc", Lang: "Go", Version: "v2"},
-		{CEKAlg: "aes_cbc", Lang: "Java", Version: "v1"},
+		{CEKAlg: "aes_cbc", Lang: "Go", Version: "v3"}, // v3 doesn't support CBC but that's where the files are
 		{CEKAlg: "aes_gcm", Lang: "Go", Version: "v3"},
 		{CEKAlg: "aes_gcm", Lang: "Java", Version: "v2"},
 		{CEKAlg: "aes_gcm", Lang: "Java", Version: "v3"},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The logic in `kms_keyring.go` has a bug where non-legacy authenticated (AES-GCM) objects will fail to decrypt when legacy unauthenticated mode is enabled. 

Note: the first commit only adds a failing test, to repro the bug. The next commit will disable the test and introduce the fix. Thereafter, I'll submit a new PR which re-enables the test against the latest version, which should pass.  


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
