### PR TITLE
chore(ci): remove bucket lifecycle policy, add function to generate legacy ciphertexts

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -16,7 +16,6 @@ import {
   BlockPublicAccess,
   BlockPublicAccessOptions,
   Bucket,
-  LifecycleRule
 } from 'aws-cdk-lib/aws-s3';
 
 export class S3ECGoGithub extends cdk.Stack {
@@ -51,16 +50,11 @@ export class S3ECGoGithub extends cdk.Stack {
       ignorePublicAcls: false,
       restrictPublicBuckets: false
     }
-    const BucketLifecycleRule: LifecycleRule = {
-        expiration: cdk.Duration.days(14),
-        id: "Expire after 14 days"
-    };
     const S3ECGithubTestS3Bucket = new Bucket(
       this,
       "S3ECGithubTestS3Bucket",
       {
         bucketName: "s3ec-go-github-test-bucket",
-        lifecycleRules: [BucketLifecycleRule],
         blockPublicAccess: new BlockPublicAccess(AccessConfiguration)
       }
     )

--- a/v3/testvectors/compatibility_test.go
+++ b/v3/testvectors/compatibility_test.go
@@ -61,6 +61,50 @@ func LoadAwsAccountId() string {
 	return os.Getenv(awsAccountIdEnvvar)
 }
 
+// This generates CBC ciphertexts that the s3_integ_test decrypts.
+// This is meant to be a utility function, not a test function,
+// but for simplicity and easy invocation it is a test function.
+// To avoid running it each test run, it is left commented out.
+//func TestGenerateCBCIntegTests(t *testing.T) {
+//	arn := "arn:aws:kms:us-west-2:370957321024:alias/S3EC-Go-Github-KMS-Key"
+//	bucket := "s3ec-go-github-test-bucket"
+//	region := "us-west-2"
+//	ctx := context.Background()
+//	cfg, _ := config.LoadDefaultConfig(ctx,
+//		config.WithRegion(region),
+//	)
+//
+//	s3Client := s3.NewFromConfig(cfg)
+//	fixtures := getFixtures(t, s3Client, "aes_cbc", bucket)
+//	// V2 client
+//	var handler s3cryptoV2.CipherDataGenerator
+//	sessKms, _ := sessionV1.NewSession(&awsV1.Config{
+//		Region: aws.String(region),
+//	})
+//
+//	// KMS v1
+//	kmsSvc := kmsV1.New(sessKms)
+//	handler = s3cryptoV2.NewKMSKeyGenerator(kmsSvc, arn)
+//	// AES-CBC content cipher
+//	builder := s3cryptoV2.AESCBCContentCipherBuilder(handler, s3cryptoV2.AESCBCPadder)
+//	encClient := s3cryptoV2.NewEncryptionClient(sessKms, builder)
+//
+//	for caseKey, plaintext := range fixtures.Plaintexts {
+//		_, err := encClient.PutObject(&s3V1.PutObjectInput{
+//			Bucket: aws.String(bucket),
+//			Key: aws.String(
+//				fmt.Sprintf("%s/%s/language_Go/ciphertext_test_case_%s",
+//					fixtures.BaseFolder, version, caseKey),
+//			),
+//			Body: bytes.NewReader(plaintext),
+//		})
+//		if err != nil {
+//			t.Fatalf("failed to upload encrypted fixture, %v", err)
+//		}
+//	}
+//
+//}
+
 func TestKmsV1toV3_CBC(t *testing.T) {
 	bucket := LoadBucket()
 	kmsKeyAlias := LoadAwsKmsAlias()


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* The CI for main is failing: https://github.com/aws/amazon-s3-encryption-client-go/actions/runs/8514198755/job/23319443015. This is because the tests expect to see ciphertexts produced by previous versions of the S3EC for Java, which are generated once and stored in the CI's S3 bucket. However, this bucket was configured with a lifecycle retention policy which deletes objects after 14 days. 

```
cdk diff
```

yields

```
Stack S3ECGoGithub
Resources
[~] AWS::S3::Bucket S3ECGithubTestS3Bucket S3ECGithubTestS3Bucket36A6F2D0
 └─ [-] LifecycleConfiguration
     └─ {"Rules":[{"ExpirationInDays":14,"Id":"Expire after 14 days","Status":"Enabled"}]}


✨  Number of stacks with differences: 1
```

Note that I have already manually deleted the lifecycle rule, so that I can fix CI and not have to worry about this causing future issues. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
