### PR TITLE
fix: fix legacy mode bug in both KMS keyrings

### DIFF
--- a/v3/materials/kms_keyring.go
+++ b/v3/materials/kms_keyring.go
@@ -133,7 +133,7 @@ func (k *KmsKeyring) OnDecrypt(ctx context.Context, materials *DecryptionMateria
 
 	if materials.DataKey.DataKeyAlgorithm == KMSKeyring && k.legacyWrappingAlgorithms {
 		return commonDecrypt(ctx, materials, encryptedDataKey, &k.KmsKeyId, nil, k.kmsClient)
-	} else if materials.DataKey.DataKeyAlgorithm == KMSContextKeyring && !k.legacyWrappingAlgorithms {
+	} else if materials.DataKey.DataKeyAlgorithm == KMSContextKeyring {
 		return commonDecrypt(ctx, materials, encryptedDataKey, &k.KmsKeyId, materials.MaterialDescription, k.kmsClient)
 	} else {
 		return nil, fmt.Errorf("x-amz-cek-alg value `%s` did not match an expected algorithm", materials.DataKey.DataKeyAlgorithm)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* See https://github.com/aws/amazon-s3-encryption-client-go/pull/45. Same fix, in the `KMSKeying` and not just the `KMSAnyKeyKeyring`. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
