### PR TITLE
chore: use %w for error types in string formatting

### DIFF
--- a/v3/client/decrypt_middleware.go
+++ b/v3/client/decrypt_middleware.go
@@ -103,7 +103,7 @@ func (m *decryptMiddleware) HandleDeserialize(ctx context.Context, in middleware
 
 	decryptMaterials, err := m.client.Options.CryptographicMaterialsManager.DecryptMaterials(ctx, decryptMaterialsRequest)
 	if err != nil {
-		return out, metadata, fmt.Errorf("error while decrypting materials: %v", err)
+		return out, metadata, fmt.Errorf("error while decrypting materials: %w", err)
 	}
 
 	cipher, err := cekFunc(*decryptMaterials)

--- a/v3/internal/object_metadata.go
+++ b/v3/internal/object_metadata.go
@@ -83,12 +83,12 @@ func (e *ObjectMetadata) UnmarshalJSON(value []byte) error {
 
 	e.TagLen, err = getJSONNumberAsString(inner.TagLen)
 	if err != nil {
-		return fmt.Errorf("failed to parse tag length: %v", err)
+		return fmt.Errorf("failed to parse tag length: %w", err)
 	}
 
 	e.UnencryptedContentLen, err = getJSONNumberAsString(inner.UnencryptedContentLen)
 	if err != nil {
-		return fmt.Errorf("failed to parse unencrypted content length: %v", err)
+		return fmt.Errorf("failed to parse unencrypted content length: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
*Issue #, if available:* n/a (see below)

*Description of changes:* 

> What's the reason for the S3 encryption SDK in Golang to use %v for error formatting rather than %w?
As far as I know, %v prevents the error from wrapping the original error. This means that for example, it's impossible to retrieve the underlying KMS error from the error returned by the SDK without performing some shady message parsing.
golang fmt source code: https://github.com/golang/go/blob/master/src/fmt/print.go#L1162-L1164
I assume this could be for compatibility with go <1.13? However the Readme calls out The v3 encryption client requires a minimum version of Go 1.20. anyway.

This change moves string formatting to use `%w` instead of `%v` when the type is `Error`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
