### PR TITLE
Fix PutObject with empty body

### DIFF
--- a/v3/internal/hash_io.go
+++ b/v3/internal/hash_io.go
@@ -24,6 +24,9 @@ func NewContentLengthReader(f io.Reader) *contentLengthReader {
 }
 
 func (r *contentLengthReader) Read(b []byte) (int, error) {
+	if r.body == nil {
+		return 0, io.EOF
+	}
 	n, err := r.body.Read(b)
 	if err != nil && err != io.EOF {
 		return n, err


### PR DESCRIPTION
*Description of changes:*

If an empty `bytes.Buffer` is provided to a `PutObject`, then this leads to a panic.
1. We call `req.SetStream` https://github.com/aws/amazon-s3-encryption-client-go/blob/e68ea95a0a7532bdd3a3e8d09f8e80d35a4ae92f/v3/client/encrypt_middleware.go#L69, which explicitly sets `reqCopy.stream` to `nil`: https://github.com/aws/smithy-go/blob/a7d0f1ef5f730836889f670f8d739456fc940779/transport/http/request.go#L126
2. We're calling `r.body.Read` w/o checking if body is `nil` and getting a panic: https://github.com/aws/amazon-s3-encryption-client-go/blob/e68ea95a0a7532bdd3a3e8d09f8e80d35a4ae92f/v3/internal/hash_io.go#L27


```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1011e8298]

goroutine 19 [running]:
testing.tRunner.func1.2({0x101309f20, 0x10163f3a0})
	/opt/homebrew/Cellar/go/1.23.5/libexec/src/testing/testing.go:1632 +0x1bc
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.23.5/libexec/src/testing/testing.go:1635 +0x334
panic({0x101309f20?, 0x10163f3a0?})
	/opt/homebrew/Cellar/go/1.23.5/libexec/src/runtime/panic.go:785 +0x124
github.com/aws/amazon-s3-encryption-client-go/v3/internal.(*contentLengthReader).Read(0x140002280c0, {0x1400023a400?, 0x14000286838?, 0x100eb70e8?})
	/Users/ivan/workato/amazon-s3-encryption-client-go/v3/internal/hash_io.go:27 +0x28
io.ReadAll({0x101397300, 0x140002280c0})
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
