### PR TITLE
fix: PutObject with empty body panics

### DIFF
--- a/v3/internal/hash_io.go
+++ b/v3/internal/hash_io.go
@@ -24,6 +24,9 @@ func NewContentLengthReader(f io.Reader) *contentLengthReader {
 }
 
 func (r *contentLengthReader) Read(b []byte) (int, error) {
+	if r.body == nil {
+		return 0, io.EOF
+	}
 	n, err := r.body.Read(b)
 	if err != nil && err != io.EOF {
 		return n, err


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Copy of https://github.com/aws/amazon-s3-encryption-client-go/pull/64 so CI can run with the correct permissions


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
