### PR TITLE
fix: return a decode error for malformed material description

### DIFF
--- a/v3/client/decrypt_middleware.go
+++ b/v3/client/decrypt_middleware.go
@@ -43,6 +43,11 @@ func customS3Decoder(matDesc string) (decoded string, e error) {
 			// We are dealing with UTF-16 encoded codepoints
 			// of the original UTF-8 characters.
 			// So, take two bytes at a time...
+			// The high-bit byte is consumed as a pair with the next byte;
+			// reject a material description that ends mid-pair.
+			if i+1 >= len(s) {
+				return "", fmt.Errorf("error while decoding material description: incomplete multi-byte sequence")
+			}
 			buf := []byte{s[i], s[i+1]}
 			// Get the rune (code point)
 			wrongRune := string(buf)

--- a/v3/client/decrypt_middleware_matdesc_test.go
+++ b/v3/client/decrypt_middleware_matdesc_test.go
@@ -14,6 +14,7 @@ func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 		"trailing high byte":     "abc\xff",
 		"single high byte":       "\xff",
 		"single 0x80 byte":       "\x80",
+		"valid UTF-8 3-byte rune": "€",
 		"mime-encoded high byte": "=?utf-8?B?gA==?=",     // base64 "gA==" -> 0x80
 		"mime-encoded abc+ff":    "=?utf-8?B?YWJj/w==?=", // base64 of "abc\xff"
 	}

--- a/v3/client/decrypt_middleware_matdesc_test.go
+++ b/v3/client/decrypt_middleware_matdesc_test.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+)
+
+// Assert customS3Decoder doesn't panic if reading an odd number of bytes;
+// a tampered material description must return a decode error instead.
+func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
+	cases := map[string]string{
+		"trailing high byte":     "abc\xff",
+		"single high byte":       "\xff",
+		"single 0x80 byte":       "\x80",
+		"mime-encoded high byte": "=?utf-8?B?gA==?=",     // base64 "gA==" -> 0x80
+		"mime-encoded abc+ff":    "=?utf-8?B?YWJj/w==?=", // base64 of "abc\xff"
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := customS3Decoder(in)
+			if err == nil {
+				t.Fatalf("expected a decode error for %q, got decoded=%q, err=nil", in, out)
+			}
+		})
+	}
+}
+
+// Well-formed ASCII JSON material descriptions must decode unchanged.
+func TestCustomS3Decoder_ValidJSONUnchanged(t *testing.T) {
+	for _, in := range []string{`{"foo":"bar"}`, `{}`} {
+		out, err := customS3Decoder(in)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", in, err)
+		}
+		if out != in {
+			t.Fatalf("expected %q unchanged, got %q", in, out)
+		}
+	}
+}

--- a/v3/client/decrypt_middleware_matdesc_test.go
+++ b/v3/client/decrypt_middleware_matdesc_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// A malformed material description must return a decode error.
+// Assert customS3Decoder doesn't panic if reading a tampered, invalid material description.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
 		"mime 0x80":         "=?utf-8?B?gA==?=",

--- a/v3/client/decrypt_middleware_matdesc_test.go
+++ b/v3/client/decrypt_middleware_matdesc_test.go
@@ -11,12 +11,10 @@ import (
 // a tampered material description must return a decode error instead.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
-		"trailing high byte":     "abc\xff",
-		"single high byte":       "\xff",
-		"single 0x80 byte":       "\x80",
+		"trailing high byte":      "abc\xff",
+		"single high byte":        "\xff",
 		"valid UTF-8 3-byte rune": "€",
-		"mime-encoded high byte": "=?utf-8?B?gA==?=",     // base64 "gA==" -> 0x80
-		"mime-encoded abc+ff":    "=?utf-8?B?YWJj/w==?=", // base64 of "abc\xff"
+		"mime-encoded high byte":  "=?utf-8?B?gA==?=", // base64 "gA==" -> 0x80
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/v3/client/decrypt_middleware_matdesc_test.go
+++ b/v3/client/decrypt_middleware_matdesc_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 )
 
-// Assert customS3Decoder doesn't panic if reading an odd number of bytes;
-// a tampered material description must return a decode error instead.
+// A malformed material description must return a decode error.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
 		"mime 0x80":         "=?utf-8?B?gA==?=",

--- a/v3/client/decrypt_middleware_matdesc_test.go
+++ b/v3/client/decrypt_middleware_matdesc_test.go
@@ -11,10 +11,10 @@ import (
 // a tampered material description must return a decode error instead.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
-		"trailing high byte":      "abc\xff",
-		"single high byte":        "\xff",
-		"valid UTF-8 3-byte rune": "€",
-		"mime-encoded high byte":  "=?utf-8?B?gA==?=", // base64 "gA==" -> 0x80
+		"mime 0x80":         "=?utf-8?B?gA==?=",
+		"mime 0xff":         "=?utf-8?B?/w==?=",
+		"mime abc+0xff":     "=?utf-8?B?YWJj/w==?=",
+		"raw trailing 0xff": "abc\xff",
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/v4/client/decrypt_middleware.go
+++ b/v4/client/decrypt_middleware.go
@@ -43,6 +43,11 @@ func customS3Decoder(matDesc string) (decoded string, e error) {
 			// We are dealing with UTF-16 encoded codepoints
 			// of the original UTF-8 characters.
 			// So, take two bytes at a time...
+			// The high-bit byte is consumed as a pair with the next byte;
+			// reject a material description that ends mid-pair.
+			if i+1 >= len(s) {
+				return "", fmt.Errorf("error while decoding material description: incomplete multi-byte sequence")
+			}
 			buf := []byte{s[i], s[i+1]}
 			// Get the rune (code point)
 			wrongRune := string(buf)

--- a/v4/client/decrypt_middleware_matdesc_test.go
+++ b/v4/client/decrypt_middleware_matdesc_test.go
@@ -14,6 +14,7 @@ func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 		"trailing high byte":     "abc\xff",
 		"single high byte":       "\xff",
 		"single 0x80 byte":       "\x80",
+		"valid UTF-8 3-byte rune": "€",
 		"mime-encoded high byte": "=?utf-8?B?gA==?=",     // base64 "gA==" -> 0x80
 		"mime-encoded abc+ff":    "=?utf-8?B?YWJj/w==?=", // base64 of "abc\xff"
 	}

--- a/v4/client/decrypt_middleware_matdesc_test.go
+++ b/v4/client/decrypt_middleware_matdesc_test.go
@@ -1,0 +1,41 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+)
+
+// Assert customS3Decoder doesn't panic if reading an odd number of bytes;
+// a tampered material description must return a decode error instead.
+func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
+	cases := map[string]string{
+		"trailing high byte":     "abc\xff",
+		"single high byte":       "\xff",
+		"single 0x80 byte":       "\x80",
+		"mime-encoded high byte": "=?utf-8?B?gA==?=",     // base64 "gA==" -> 0x80
+		"mime-encoded abc+ff":    "=?utf-8?B?YWJj/w==?=", // base64 of "abc\xff"
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			out, err := customS3Decoder(in)
+			if err == nil {
+				t.Fatalf("expected a decode error for %q, got decoded=%q, err=nil", in, out)
+			}
+		})
+	}
+}
+
+// Well-formed ASCII JSON material descriptions must decode unchanged.
+func TestCustomS3Decoder_ValidJSONUnchanged(t *testing.T) {
+	for _, in := range []string{`{"foo":"bar"}`, `{}`} {
+		out, err := customS3Decoder(in)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", in, err)
+		}
+		if out != in {
+			t.Fatalf("expected %q unchanged, got %q", in, out)
+		}
+	}
+}

--- a/v4/client/decrypt_middleware_matdesc_test.go
+++ b/v4/client/decrypt_middleware_matdesc_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// A malformed material description must return a decode error.
+// Assert customS3Decoder doesn't panic if reading a tampered, invalid material description.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
 		"mime 0x80":         "=?utf-8?B?gA==?=",

--- a/v4/client/decrypt_middleware_matdesc_test.go
+++ b/v4/client/decrypt_middleware_matdesc_test.go
@@ -11,12 +11,10 @@ import (
 // a tampered material description must return a decode error instead.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
-		"trailing high byte":     "abc\xff",
-		"single high byte":       "\xff",
-		"single 0x80 byte":       "\x80",
+		"trailing high byte":      "abc\xff",
+		"single high byte":        "\xff",
 		"valid UTF-8 3-byte rune": "€",
-		"mime-encoded high byte": "=?utf-8?B?gA==?=",     // base64 "gA==" -> 0x80
-		"mime-encoded abc+ff":    "=?utf-8?B?YWJj/w==?=", // base64 of "abc\xff"
+		"mime-encoded high byte":  "=?utf-8?B?gA==?=", // base64 "gA==" -> 0x80
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/v4/client/decrypt_middleware_matdesc_test.go
+++ b/v4/client/decrypt_middleware_matdesc_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 )
 
-// Assert customS3Decoder doesn't panic if reading an odd number of bytes;
-// a tampered material description must return a decode error instead.
+// A malformed material description must return a decode error.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
 		"mime 0x80":         "=?utf-8?B?gA==?=",

--- a/v4/client/decrypt_middleware_matdesc_test.go
+++ b/v4/client/decrypt_middleware_matdesc_test.go
@@ -11,10 +11,10 @@ import (
 // a tampered material description must return a decode error instead.
 func TestCustomS3Decoder_TruncatedMultiByteReturnsError(t *testing.T) {
 	cases := map[string]string{
-		"trailing high byte":      "abc\xff",
-		"single high byte":        "\xff",
-		"valid UTF-8 3-byte rune": "€",
-		"mime-encoded high byte":  "=?utf-8?B?gA==?=", // base64 "gA==" -> 0x80
+		"mime 0x80":         "=?utf-8?B?gA==?=",
+		"mime 0xff":         "=?utf-8?B?/w==?=",
+		"mime abc+0xff":     "=?utf-8?B?YWJj/w==?=",
+		"raw trailing 0xff": "abc\xff",
 	}
 	for name, in := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix `customS3Decoder` panic when reading a tampered, invalid material description

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.